### PR TITLE
fix: add the missing module in startKoin block

### DIFF
--- a/app/src/main/java/com/antonioleiva/cleanarchitecturesample/App.kt
+++ b/app/src/main/java/com/antonioleiva/cleanarchitecturesample/App.kt
@@ -13,7 +13,7 @@ class App : Application() {
         startKoin {
             androidLogger()
             androidContext(this@App)
-            modules(listOf(dataModule, useCaseModule, appModule))
+            modules(listOf(dataModule, useCaseModule, appModule, presentersModule))
         }
     }
 }


### PR DESCRIPTION
Hi, Antonio. Thanks for your nice article and sample about Clean Architecture. After it, I more clearly understand this concept. When I built the project, I found that presentersModule not set in startKoin block. In this PR I added the missing module. 
In the presenter, you use GlobalScope. Do you use it only for example? In a real project, how you organize work with coroutines in presenters?